### PR TITLE
collect data from bci 

### DIFF
--- a/software/speller/data_collection_platform/dcp/api.py
+++ b/software/speller/data_collection_platform/dcp/api.py
@@ -52,9 +52,9 @@ def openbci_start():
     from dcp.bci.stream import stream_bci_api
     from multiprocessing import Process
     with current_app.app_context():
-        p = Process(target=stream_bci_api, args=(shared.bci_running,))
+        p = Process(target=stream_bci_api, args=(shared.bci_processes_states,))
         p.start()
-        shared.bci_running[p.pid] = True
+        shared.bci_processes_states[p.pid] = True
     return {"data": {"pid": p.pid}}, 201
 
 
@@ -71,7 +71,7 @@ def openbci_stop(process_id: int):
     # We need some kind of process manager, and call
     # mp.Process.terminate() and mp.Process.kill() directly.
     # This would also allow us to use mp.Process.is_alive().
-    shared.bci_running[process_id] = False
+    shared.bci_processes_states[process_id] = False
     os.kill(process_id, signal.SIGTERM)
     return {}, 200
 

--- a/software/speller/data_collection_platform/dcp/api.py
+++ b/software/speller/data_collection_platform/dcp/api.py
@@ -49,11 +49,12 @@ def char_pressed():
 @bp.route("/openbci/start", methods=['POST'])
 def openbci_start():
     # use a separate process to stream BCI data
-    from dcp.bci.stream import stream_bci
+    from dcp.bci.stream import stream_bci_api
     from multiprocessing import Process
     with current_app.app_context():
-        p = Process(target=stream_bci)
+        p = Process(target=stream_bci_api, args=(shared.bci_running,))
         p.start()
+        shared.bci_running[p.pid] = True
     return {"data": {"pid": p.pid}}, 201
 
 
@@ -70,6 +71,7 @@ def openbci_stop(process_id: int):
     # We need some kind of process manager, and call
     # mp.Process.terminate() and mp.Process.kill() directly.
     # This would also allow us to use mp.Process.is_alive().
+    shared.bci_running[process_id] = False
     os.kill(process_id, signal.SIGTERM)
     return {}, 200
 

--- a/software/speller/data_collection_platform/dcp/bci/stream.py
+++ b/software/speller/data_collection_platform/dcp/bci/stream.py
@@ -21,7 +21,7 @@ logging.basicConfig(filename=log_path,
 logger = logging.getLogger(__name__)
 logger.info('test logger')
 
-def stream_bci_api(bci_running): 
+def stream_bci_api(bci_processes_states): 
     # Some imports are only in this section, to allow other functions to be tested outside of the flask app
     # The relative import paths make this difficult to test in isolation
     # TODO: currently the collecting shared variable is in another branch, will have to test with other branch to see if this works
@@ -50,13 +50,13 @@ def stream_bci_api(bci_running):
     # this machine
     inlet.time_correction()
 
-    while bci_running[os.getpid()] == False:
+    while bci_processes_states[os.getpid()] == False:
         continue
         # this will ensure that there is no race condition, and that the parent process has been able to instantiate this variable
 
     # os.getpid()
     # running = True
-    while bci_running[os.getpid()]:
+    while bci_processes_states[os.getpid()]:
         samples, _timestamps = inlet.pull_chunk()
 
         if not samples:

--- a/software/speller/data_collection_platform/dcp/bci/stream.py
+++ b/software/speller/data_collection_platform/dcp/bci/stream.py
@@ -21,8 +21,6 @@ logging.basicConfig(filename=log_path,
 logger = logging.getLogger(__name__)
 logger.info('test logger')
 
-duration = 5
-
 def stream_bci_api(bci_running): 
     # Some imports are only in this section, to allow other functions to be tested outside of the flask app
     # The relative import paths make this difficult to test in isolation
@@ -91,7 +89,7 @@ def connect_to_bci():
     print(bci_config)
     return inlet
 
-def testLSLSamplingRate(inlet):
+def testLSLSamplingRate(inlet, duration):
     start = time.time()
     totalNumSamples = 0
     validSamples = 0
@@ -115,8 +113,9 @@ def testLSLSamplingRate(inlet):
     print( "Avg Sampling Rate == {}".format(validSamples / duration) )
 
 if __name__ == '__main__':
+    duration = 5
     inlet = connect_to_bci()
-    testLSLSamplingRate(inlet)
+    testLSLSamplingRate(inlet, duration)
     # while True:
     #     chunk, timestamp = inlet.pull_chunk()
     #     if chunk:

--- a/software/speller/data_collection_platform/dcp/bci/stream.py
+++ b/software/speller/data_collection_platform/dcp/bci/stream.py
@@ -1,1 +1,123 @@
-# TODO stephen
+"""
+This file will allow the application to connect to the BCI process
+and collect the brain signals being streamed
+This code is based on
+1. https://github.com/OpenBCI/OpenBCI_GUI/blob/master/Networking-Test-Kit/LSL/lslStreamTest.py
+2. the previous years stream.py found at NeuroTechX-McGill-2021/software/data_collection_platform/backend/dcp/bci/stream.py
+"""
+
+from pylsl import StreamInlet, resolve_stream
+import time 
+import logging
+import os
+
+log_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__)))), "logs",
+                        "bci.log")
+
+logging.basicConfig(filename=log_path,
+                    level=logging.INFO,
+                    format="%(asctime)s %(name)s %(levelname)s %(message)s")
+
+logger = logging.getLogger(__name__)
+logger.info('test logger')
+
+duration = 5
+
+def stream_bci_api(bci_running): 
+    # Some imports are only in this section, to allow other functions to be tested outside of the flask app
+    # The relative import paths make this difficult to test in isolation
+    # TODO: currently the collecting shared variable is in another branch, will have to test with other branch to see if this works
+    # from dcp.mp.shared import collecting
+    from dcp.mp.shared import q
+    # TODO: this next import has to do with the DB, and reading the BCI config ID
+    # will need to be done once the db is fully setup
+    # from dcp.models.configurations import OpenBCIConfig
+
+    # from multiprocessing import current_process
+    logger.info('Attempting to initialize stream')
+
+    inlet = connect_to_bci()
+
+    logger.info('Succesfully connected to an inlet stream')
+    logger.info(inlet.info().as_xml())
+
+    # TODO: save current configuration to database once it is ready
+    # db.session.add(config)
+    # db.session.commit()
+
+    # TAKEN FROM LAST YEAR:
+    # retrieve estimated time correction offset for the given stream - this is
+    # the number that needs to be added to a timestamp that was remotely
+    # generated via local_clock() to map it into the local clock domain for
+    # this machine
+    inlet.time_correction()
+
+    while bci_running[os.getpid()] == False:
+        continue
+        # this will ensure that there is no race condition, and that the parent process has been able to instantiate this variable
+
+    # os.getpid()
+    # running = True
+    while bci_running[os.getpid()]:
+        samples, _timestamps = inlet.pull_chunk()
+
+        if not samples:
+            continue
+        # TODO: uncomment this section to check the collecting value
+        # with collecting.get_lock():
+        #     if collecting.value:
+        q.put_nowait(samples)
+    
+        logger.info(samples)
+
+    logger.info("no longer running")
+    return 'success'
+
+
+def connect_to_bci():
+    # first resolve an EEG stream on the lab network
+    # NOTE: this will block until a connection is established
+    print("looking for an EEG stream...")
+    streams = resolve_stream('type', 'EEG')
+
+    print('connected to EEG streams')
+    if len(streams) == 1:
+        inlet = StreamInlet(streams[0])
+        print('only 1 stream, we are good to proceed')
+        # logger.info("Connected to stream.")
+
+    # get information about the stream
+    bci_config = inlet.info().as_xml()
+    print(bci_config)
+    return inlet
+
+def testLSLSamplingRate(inlet):
+    start = time.time()
+    totalNumSamples = 0
+    validSamples = 0
+    numChunks = 0
+    print( "Testing Sampling Rates..." )
+
+    while time.time() <= start + duration:
+        # get chunks of samples
+        chunk, timestamp = inlet.pull_chunk()
+        if chunk:
+            numChunks += 1
+            # print( len(chunk) )
+            totalNumSamples += len(chunk)
+            # print(chunk);
+            for sample in chunk:
+                # print(sample)
+                validSamples += 1
+
+    print( "Number of Chunks and Samples == {} , {}".format(numChunks, totalNumSamples) )
+    print( "Valid Samples and Duration == {} / {}".format(validSamples, duration) )
+    print( "Avg Sampling Rate == {}".format(validSamples / duration) )
+
+if __name__ == '__main__':
+    inlet = connect_to_bci()
+    testLSLSamplingRate(inlet)
+    # while True:
+    #     chunk, timestamp = inlet.pull_chunk()
+    #     if chunk:
+    #         print('got chunk')

--- a/software/speller/data_collection_platform/dcp/mp/shared.py
+++ b/software/speller/data_collection_platform/dcp/mp/shared.py
@@ -1,6 +1,6 @@
 """This file holds the shared variables between processes."""
 
-from multiprocessing import Queue, Value
+from multiprocessing import Queue, Value, Manager
 
 # NOTE: anytime we want to write/read the shared variables, one must acquire and release the lock to avoid racing issues between processes/threads
 # NOTE: we could use another queue for message passing between processes would be more efficient
@@ -19,3 +19,8 @@ bci_config_id = Value("i", 0)
 
 # communicate whether the BCI device is ready (connected)
 is_bci_ready = Value("i", 0)
+
+# creating a manager that will allow processes to be communicated to from the flask app
+# the manager will control when processes can pull from the bci device
+manager = Manager()
+bci_running = manager.dict()

--- a/software/speller/data_collection_platform/dcp/mp/shared.py
+++ b/software/speller/data_collection_platform/dcp/mp/shared.py
@@ -23,4 +23,4 @@ is_bci_ready = Value("i", 0)
 # creating a manager that will allow processes to be communicated to from the flask app
 # the manager will control when processes can pull from the bci device
 manager = Manager()
-bci_running = manager.dict()
+bci_processes_states = manager.dict()


### PR DESCRIPTION
modified stream.py to collect from bci machine, modified the api endpoint to create a dictionary so that parent process can communicate with child, added an additional dictionary in shared.py

The current flow works as follows:
1. the user instantiated the flask app
2. when the endpoint /api/openbci/start gets hit with a POST request, the flask app spawns a new process
3. the flask app process will update the shared dictionary with the entry dict[subprocess.pid] = True
4. the child process will connect to the bci machine and collect data to put into the Queue (q)
5. Once the endpoint /api/openbci/:process_id/stop is hit with a POST again, the subprocess will be terminated

Currently, we will assume that the flask app process will need to run another call or subprocess to send the information stored in the queue to the database.

This pull request will also depend on the other pull request, with manages shared variables, since it is assumed that the shared variable "collecting" will be needed to determine when the subprocess can collect data from the bci machine.

This current iteration will also store informatiion in the log.

What has been tested:
I've manually tested that the stream.py is able to connect to the bci machine, and obtain data.
I've also tested the two endpoints to ensure that it spawns a new process which collects data, and that the stop endpoint terminates this process.
The logs currently work, but they are very bare.

Further work:
This current iteration does not interact with the database at all.
We also need to add additional support for the new shared variable "collecting", and ensure that we are storing all the information (such as frequency, letter, ...) 